### PR TITLE
adapt tests to dplyr 0.8.0

### DIFF
--- a/tests/testthat/test_eval_tibbles.R
+++ b/tests/testthat/test_eval_tibbles.R
@@ -821,7 +821,16 @@ expected_df <- structure(list(fun = c("gen_data", "gen_data"), replications = c(
   ), row.names = c(NA, -3L), class = c(
     "grouped_df",
     "tbl_df", "tbl", "data.frame"
-  ), vars = "group1", drop = TRUE),
+  ), 
+    groups = structure(list(
+        group1 = c("a", "b", "c"), 
+        .rows = list(1L, 2L, 3L)
+      ), 
+      row.names = c(NA, -3L), 
+      class = c("tbl_df", "tbl", "data.frame"), 
+      .drop = TRUE
+    )
+  ),
   sum = structure(list(group1 = c("a", "b", "c"), group2 = c(
     "d",
     "e", "f"
@@ -831,7 +840,16 @@ expected_df <- structure(list(fun = c("gen_data", "gen_data"), replications = c(
   ), row.names = c(NA, -3L), class = c(
     "grouped_df", "tbl_df",
     "tbl", "data.frame"
-  ), vars = "group1", drop = TRUE)
+  ), 
+    groups = structure(list(
+        group1 = c("a", "b", "c"), 
+        .rows = list(1L, 2L, 3L)
+      ), 
+      row.names = c(NA, -3L), 
+      class = c("tbl_df", "tbl", "data.frame"), 
+      .drop = TRUE
+    )
+  )
 ), .Names = c(
   "mean",
   "sum"


### PR DESCRIPTION
This adapts the tests so that it passes based on dplyr 0.8.0, released soon. 

This probably should not use the internals of how a grouped data frame is represented, but rather adapt the tests so that it tests specific things, as unfortunately this new version of the test file would not pass on dplyr 0.7.8