### PR TITLE
using expect_equivalent() instead of expect_identical()

### DIFF
--- a/tests/testthat/test_bind_or_combine.R
+++ b/tests/testthat/test_bind_or_combine.R
@@ -6,7 +6,7 @@ test_that("Unnamed vector combined to one column", {
 })
 
 test_that("Named vectors combined to multiple columns", {
-  expect_identical(
+  expect_equivalent(
     bind_or_combine(c(min = 1, max = 1), c(min = 2, max = 3), c(a = 1)),
     tibble::tibble(min = c(1, 2, NA), max = c(1, 3, NA), a = c(NA, NA, 1))
   )

--- a/tests/testthat/test_eval_tibbles.R
+++ b/tests/testthat/test_eval_tibbles.R
@@ -582,7 +582,7 @@ structure(list(value = 2), .Names = "value", row.names = c(
 test_that("Three analyzing functions and one summary function.
           Results were created and stored in simulation", {
   for (col in colnames(eg$simulation)) {
-    expect_identical(eg$simulation[[col]], expected_df[[col]])
+    expect_equivalent(eg$simulation[[col]], expected_df[[col]])
   }
 })
 
@@ -740,7 +740,7 @@ structure(list(value = 8L), .Names = "value", row.names = c(
 test_that("Three analyzing functions and three summary function.
           Results were created and stored in simulation", {
   for (col in colnames(eg$simulation)) {
-    expect_identical(eg$simulation[[col]], expected_df[[col]])
+    expect_equivalent(eg$simulation[[col]], expected_df[[col]])
   }
 })
 
@@ -814,7 +814,7 @@ structure(list(value = 2), .Names = "value", row.names = c(
 test_that("Three analyzing functions and one summary function over 2 cpus.
           Results were created and stored in simulation", {
   for (col in colnames(eg$simulation)) {
-    expect_identical(eg$simulation[[col]], expected_df[[col]])
+    expect_equivalent(eg$simulation[[col]], expected_df[[col]])
   }
 })
 


### PR DESCRIPTION
In the about to be released version of `dplyr`, `bind_rows()` no longer directly makes a tibble, as was the case before. 

Changing from `expect_identical()` to `expect_equivalent()` in the test makes sure the tests don't take the class into account. 